### PR TITLE
Fix broken shadow for non-16:9 Vimeo content (#63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - The case study heading is now on the top for larger screens! I don't know why I had it like that before...
 - Updated dependencies.
 
+### Fixed
+
+- Broken shadow showing up for Vimeo content that is not 16:9 by setting player's ["transparent" parameter](https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview) to false. ([#63](https://github.com/imse-ty/imsety.com/issues/63))
+
 ## [1.3.0] - 2022-05-04
 
 ### Added

--- a/components/projects/project-embed.js
+++ b/components/projects/project-embed.js
@@ -67,7 +67,7 @@ export function ProjectVimeo({ url }) {
     }
   };
   const vimeoId = getVimeoId();
-  const vimeoUrl = `https://player.vimeo.com/video/${vimeoId}?playsinline=0`;
+  const vimeoUrl = `https://player.vimeo.com/video/${vimeoId}?playsinline=0&transparent=0`;
 
   return (
     <figure


### PR DESCRIPTION
## Changes

I made the Vimeo player look more like YouTube's by setting the ["transparent" parameter](https://vimeo.zendesk.com/hc/en-us/articles/360001494447-Player-parameters-overview) to "false" in the embed's url.

## Screenshots

![Preview of new fixed Vimeo player](https://user-images.githubusercontent.com/51539572/174353963-32540663-ed96-42fd-9342-3dc32062ee95.png)
